### PR TITLE
Drop Python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 ---
+dist: bionic
+
 language: python
 
 # Run tests against each supported version while docs and style are only
 # considered on the latest supported version.
 matrix:
   include:
-    - python: 3.5
-      env: TOXENV=py35
     - python: 3.6
       env: TOXENV=py36
     - python: 3.7

--- a/docs/get.rst
+++ b/docs/get.rst
@@ -17,4 +17,4 @@ master branch:
 
 After installation ``feeds`` is available in your virtual environment.
 
-Feeds supports Python 3.5+.
+Feeds supports Python 3.6+.

--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,15 @@ setup(
         "scrapy-inline-requests",
     ],
     extras_require={
-        "docs": ["doc8", "restructuredtext_lint", "sphinx", "sphinx_rtd_theme"],
-        "style": ["black", "flake8", "isort"],
+        "docs": ["sphinx", "sphinx_rtd_theme"],
+        "style": [
+            "black",
+            "doc8",
+            "flake8",
+            "isort",
+            "pygments",
+            "restructuredtext_lint",
+        ],
         "test": ["pytest"],
     },
     entry_points={"console_scripts": ["feeds=feeds.cli:main"]},

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,6 @@ setup(
         "Intended Audience :: Developers",
         "License :: OSI Approved :: GNU Affero General Public License v3",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",

--- a/setup.py
+++ b/setup.py
@@ -26,10 +26,7 @@ setup(
         "style": ["black", "flake8", "isort"],
         "test": ["pytest"],
     },
-    entry_points="""
-        [console_scripts]
-        feeds=feeds.cli:main
-    """,
+    entry_points={"console_scripts": ["feeds=feeds.cli:main"]},
     classifiers=[
         "Development Status :: 4 - Beta",
         "Environment :: Console",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35,py36,py37,py38
+envlist = py36,py37,py38
 
 [testenv]
 description = Run tests

--- a/tox.ini
+++ b/tox.ini
@@ -15,12 +15,12 @@ commands =
     flake8 feeds
     black --check feeds
     isort --check-only -rc feeds
+    rst-lint README.rst
+    doc8 --ignore-path docs/_build docs/
+    python setup.py check --metadata --restructuredtext --strict
 
 [testenv:docs]
-description = Build and check documentation
+description = Build documentation
 extras = docs
 commands =
-    rst-lint README.rst
-    doc8 docs/
     sphinx-build -W -b html docs/ docs/_build/
-    python setup.py check --metadata --restructuredtext --strict


### PR DESCRIPTION
* Drop support for Python 3.5
* Split style and docs environment
* Avoid old-style entrypoint spec