### PR TITLE
Rework Gem2Go spider (was riskommunal)

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -152,7 +152,7 @@ scraping from there.
   * :ref:`spider_npr.org`
   * :ref:`spider_puls4.com`
   * :ref:`spider_python-patterns.guide`
-  * :ref:`spider_riskommunal`
+  * :ref:`spider_gem2go`
   * :ref:`spider_servustv.com`
   * :ref:`spider_tuwien.ac.at`
   * :ref:`spider_momoxfashion.com`

--- a/docs/spiders/gem2go.rst
+++ b/docs/spiders/gem2go.rst
@@ -1,26 +1,26 @@
-.. _spider_riskommunal:
+.. _spider_gem2go:
 
-riskommunal
------------
+gem2go
+------
 News from your local town or community, if their website is maintained with
-`RIS Kommunal <https://info.riskommunal.net/>`_.
+`GEM2GO <https://www.gem2go.at/>`_.
 
 Configuration
 ~~~~~~~~~~~~~
-Add ``riskommunal`` to the list of spiders:
+Add ``gem2go`` to the list of spiders:
 
 .. code-block:: ini
 
    # List of spiders to run by default, one per line.
    spiders =
-     riskommunal
+     gem2go
 
 At least one url is required. The local community or town website typically has
 a "News" or "Neuigkeiten" URL that you may use.
 
 .. code-block:: ini
 
-   [riskommunal]
+   [gem2go]
    urls =
        http://yourlocalcommunity.tld/News
        https://mytown.tld/BUeRGERSERVICE/Neuigkeiten

--- a/feeds.cfg.dist
+++ b/feeds.cfg.dist
@@ -176,7 +176,7 @@ useragent = feeds (+https://github.com/pyfeeds/pyfeeds)
 #    special-report
 #    leaders
 
-#[riskommunal]
+#[gem2go]
 #urls =
 #    http://yourlocalcommunity.tld/News
 #    https://mytown.tld/BUeRGERSERVICE/Neuigkeiten

--- a/feeds/spiders/gem2go.py
+++ b/feeds/spiders/gem2go.py
@@ -86,9 +86,10 @@ class Gem2GoSpider(FeedsSpider):
             dayfirst=True,
             yearfirst=False,
             remove_elems=[
-                "div.main-content h1:first-of-type",
-                "p#ctl00_ctl00_ctl00_cph_col_a_cph_content_cph_content_detail_p_date",
                 "div#main-content-header",
+                "div.main-content h1:first-of-type",
+                "div.newsdatum_container",
+                "p#ctl00_ctl00_ctl00_cph_col_a_cph_content_cph_content_detail_p_date",
             ],
         )
         il.add_value("path", site)

--- a/feeds/spiders/gem2go.py
+++ b/feeds/spiders/gem2go.py
@@ -55,15 +55,14 @@ class Gem2GoSpider(FeedsSpider):
         self._subtitles[site] = f"Neuigkeiten aus {title}"
 
         for selector in response.css("div.newslist div[class*='float_left']"):
-            updated = selector.css("p.float_right::text").get()
-            if not updated:
-                # Do not care about "archived news"
-                continue
-
             url = selector.css("a::attr(href)").get()
             if not url:
                 # Ignore articles without a link
                 continue
+
+            # The publication date might be present only on the overview page,
+            # only on the article page or mix and match on both.
+            updated = selector.css("p.float_right::text").get()
 
             yield scrapy.Request(
                 urljoin(self._links[site], url),
@@ -90,7 +89,9 @@ class Gem2GoSpider(FeedsSpider):
         il.add_value("path", site)
         il.add_value("link", response.url)
         il.add_value("updated", response.meta["updated"])
-        il.add_css("title", "div.main-content h1:first-of-type::text")
+        il.add_css("updated", ".newsdatum_container ::text")
+        il.add_css("updated", "p[id$='detail_p_date'] ::text")
+        il.add_css("title", "div.main-content h1:first-of-type ::text")
         il.add_css("content_html", "div.main-content")
 
         yield il.load_item()

--- a/feeds/spiders/gem2go.py
+++ b/feeds/spiders/gem2go.py
@@ -17,7 +17,6 @@ class Gem2GoSpider(FeedsSpider):
     _titles = {}
     _subtitles = {}
     _links = {}
-    _icons = {}
 
     def feed_headers(self):
         for site in self._sites:
@@ -25,7 +24,6 @@ class Gem2GoSpider(FeedsSpider):
                 title=self._titles.get(site),
                 subtitle=self._subtitles.get(site),
                 link=self._links.get(site),
-                icon=self._icons.get(site),
                 path=site,
             )
 
@@ -55,9 +53,6 @@ class Gem2GoSpider(FeedsSpider):
         title = response.css("meta[property='og:title']::attr(content)").get()
         self._titles[site] = title
         self._subtitles[site] = f"Neuigkeiten aus {title}"
-
-        if icon := response.css("link[rel='icon']::attr(href)").get():
-            self._icons[site] = urljoin(self._links[site], icon)
 
         for selector in response.css("div.newslist div[class*='float_left']"):
             updated = selector.css("p.float_right::text").get()


### PR DESCRIPTION
* Rename from Riskommunal to Gem2Go
* Support multiple versions of the same "CMS"
* Remove broken icon URL